### PR TITLE
Add standard traits to public structs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "web-push"
 description = "Web push notification client with support for http-ece encryption and VAPID authentication."
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Julius de Bruijn <julius+github@nauk.io>", "Andrew Ealovega <Andrew@Ealovega.dev>"]
 license = "Apache-2.0"
 homepage = "https://github.com/pimeys/rust-web-push"

--- a/src/clients/hyper_client.rs
+++ b/src/clients/hyper_client.rs
@@ -1,7 +1,7 @@
 use std::convert::Infallible;
 
 use http::header::{CONTENT_LENGTH, RETRY_AFTER};
-use hyper::{Body, body::HttpBody, Client, client::HttpConnector, Request as HttpRequest};
+use hyper::{body::HttpBody, client::HttpConnector, Body, Client, Request as HttpRequest};
 use hyper_tls::HttpsConnector;
 
 use crate::clients::request_builder;

--- a/src/clients/hyper_client.rs
+++ b/src/clients/hyper_client.rs
@@ -1,11 +1,12 @@
+use std::convert::Infallible;
+
 use http::header::{CONTENT_LENGTH, RETRY_AFTER};
-use hyper::{body::HttpBody, client::HttpConnector, Body, Client, Request as HttpRequest};
+use hyper::{Body, body::HttpBody, Client, client::HttpConnector, Request as HttpRequest};
 use hyper_tls::HttpsConnector;
 
 use crate::clients::request_builder;
 use crate::error::{RetryAfter, WebPushError};
 use crate::message::WebPushMessage;
-use std::convert::Infallible;
 
 /// An async client for sending the notification payload.
 ///

--- a/src/clients/isahc_client.rs
+++ b/src/clients/isahc_client.rs
@@ -1,10 +1,10 @@
+use futures_lite::AsyncReadExt;
 use http::header::{CONTENT_LENGTH, RETRY_AFTER};
 use isahc::HttpClient;
 
 use crate::clients::request_builder;
 use crate::error::{RetryAfter, WebPushError};
 use crate::message::WebPushMessage;
-use futures_lite::AsyncReadExt;
 
 /// An async client for sending the notification payload. This client is expensive to create, and
 /// should be reused.

--- a/src/clients/request_builder.rs
+++ b/src/clients/request_builder.rs
@@ -1,9 +1,10 @@
 //! Functions used to send and consume push http messages.
 //! This module can be used to build custom clients.
 
-use crate::{error::WebPushError, message::WebPushMessage};
-use http::header::{CONTENT_ENCODING, CONTENT_LENGTH, CONTENT_TYPE};
 use http::{Request, StatusCode};
+use http::header::{CONTENT_ENCODING, CONTENT_LENGTH, CONTENT_TYPE};
+
+use crate::{error::WebPushError, message::WebPushMessage};
 
 #[derive(Deserialize, Serialize, Debug, PartialEq)]
 struct ErrorInfo {
@@ -87,11 +88,12 @@ pub fn parse_response(response_status: StatusCode, body: Vec<u8>) -> Result<(), 
 
 #[cfg(test)]
 mod tests {
+    use http::Uri;
+
     use crate::clients::request_builder::*;
     use crate::error::WebPushError;
     use crate::http_ece::ContentEncoding;
     use crate::message::WebPushMessageBuilder;
-    use http::Uri;
 
     #[test]
     fn builds_a_correct_request_with_empty_payload() {

--- a/src/clients/request_builder.rs
+++ b/src/clients/request_builder.rs
@@ -1,8 +1,8 @@
 //! Functions used to send and consume push http messages.
 //! This module can be used to build custom clients.
 
-use http::{Request, StatusCode};
 use http::header::{CONTENT_ENCODING, CONTENT_LENGTH, CONTENT_TYPE};
+use http::{Request, StatusCode};
 
 use crate::{error::WebPushError, message::WebPushMessage};
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
-use std::{convert::From, error::Error, fmt, io::Error as IoError};
 use std::string::FromUtf8Error;
 use std::time::{Duration, SystemTime};
+use std::{convert::From, error::Error, fmt, io::Error as IoError};
 
 use base64::DecodeError;
 use http::uri::InvalidUri;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,11 +1,12 @@
+use std::{convert::From, error::Error, fmt, io::Error as IoError};
+use std::string::FromUtf8Error;
+use std::time::{Duration, SystemTime};
+
 use base64::DecodeError;
 use http::uri::InvalidUri;
 use serde_json::error::Error as JsonError;
-use std::string::FromUtf8Error;
-use std::time::{Duration, SystemTime};
-use std::{convert::From, error::Error, fmt, io::Error as IoError};
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Debug, Clone, Ord, PartialOrd, Eq, Deserialize, Serialize, Hash)]
 pub enum WebPushError {
     /// An unknown error happened encrypting the message,
     Unspecified,

--- a/src/http_ece.rs
+++ b/src/http_ece.rs
@@ -1,7 +1,8 @@
+use ece::encrypt;
+
 use crate::error::WebPushError;
 use crate::message::WebPushPayload;
 use crate::vapid::VapidSignature;
-use ece::encrypt;
 
 /// Content encoding profiles.
 pub enum ContentEncoding {
@@ -78,12 +79,13 @@ impl<'a> HttpEce<'a> {
 
 #[cfg(test)]
 mod tests {
+    use base64::{self, URL_SAFE};
+    use regex::Regex;
+
     use crate::error::WebPushError;
     use crate::http_ece::{ContentEncoding, HttpEce};
     use crate::VapidSignature;
     use crate::WebPushPayload;
-    use base64::{self, URL_SAFE};
-    use regex::Regex;
 
     #[test]
     fn test_payload_too_big() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,9 +43,20 @@
 //! ```
 
 #[macro_use]
-extern crate serde_derive;
-#[macro_use]
 extern crate log;
+#[macro_use]
+extern crate serde_derive;
+
+#[cfg(feature = "hyper-client")]
+pub use crate::clients::hyper_client::WebPushClient;
+#[cfg(not(feature = "hyper-client"))]
+pub use crate::clients::isahc_client::WebPushClient;
+pub use crate::clients::request_builder;
+pub use crate::error::WebPushError;
+pub use crate::http_ece::ContentEncoding;
+pub use crate::message::{SubscriptionInfo, SubscriptionKeys, WebPushMessage, WebPushMessageBuilder, WebPushPayload};
+pub use crate::vapid::{VapidSignature, VapidSignatureBuilder};
+pub use crate::vapid::builder::PartialVapidSignatureBuilder;
 
 mod clients;
 mod error;
@@ -53,18 +64,3 @@ mod http_ece;
 mod message;
 mod vapid;
 
-#[cfg(feature = "hyper-client")]
-pub use crate::clients::hyper_client::WebPushClient;
-
-#[cfg(not(feature = "hyper-client"))]
-pub use crate::clients::isahc_client::WebPushClient;
-
-pub use crate::error::WebPushError;
-
-pub use crate::message::{SubscriptionInfo, SubscriptionKeys, WebPushMessage, WebPushMessageBuilder, WebPushPayload};
-
-pub use crate::http_ece::ContentEncoding;
-pub use crate::vapid::builder::PartialVapidSignatureBuilder;
-pub use crate::vapid::{VapidSignature, VapidSignatureBuilder};
-
-pub use crate::clients::request_builder;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,12 +55,11 @@ pub use crate::clients::request_builder;
 pub use crate::error::WebPushError;
 pub use crate::http_ece::ContentEncoding;
 pub use crate::message::{SubscriptionInfo, SubscriptionKeys, WebPushMessage, WebPushMessageBuilder, WebPushPayload};
-pub use crate::vapid::{VapidSignature, VapidSignatureBuilder};
 pub use crate::vapid::builder::PartialVapidSignatureBuilder;
+pub use crate::vapid::{VapidSignature, VapidSignatureBuilder};
 
 mod clients;
 mod error;
 mod http_ece;
 mod message;
 mod vapid;
-

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,10 +1,11 @@
+use http::uri::Uri;
+
 use crate::error::WebPushError;
 use crate::http_ece::{ContentEncoding, HttpEce};
 use crate::vapid::VapidSignature;
-use http::uri::Uri;
 
 /// Encryption keys from the client.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone, Eq, PartialEq, Ord, PartialOrd, Default, Hash)]
 pub struct SubscriptionKeys {
     /// The public key. Base64 encoded.
     pub p256dh: String,
@@ -16,7 +17,7 @@ pub struct SubscriptionKeys {
 /// subscription info JSON data (AKA pushSubscription object).
 ///
 /// Client pushSubscription objects can be directly deserialized into this struct using serde.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone, Eq, PartialEq, Ord, PartialOrd, Default, Hash)]
 pub struct SubscriptionInfo {
     /// The endpoint URI for sending the notification.
     pub endpoint: String,

--- a/src/vapid/builder.rs
+++ b/src/vapid/builder.rs
@@ -7,8 +7,8 @@ use serde_json::Value;
 
 use crate::error::WebPushError;
 use crate::message::SubscriptionInfo;
-use crate::vapid::{VapidKey, VapidSignature, VapidSigner};
 use crate::vapid::signer::Claims;
+use crate::vapid::{VapidKey, VapidSignature, VapidSigner};
 
 /// A VAPID signature builder for generating an optional signature to the
 /// request. This encryption is required for payloads in all current and future browsers.

--- a/src/vapid/builder.rs
+++ b/src/vapid/builder.rs
@@ -1,12 +1,14 @@
-use crate::error::WebPushError;
-use crate::message::SubscriptionInfo;
-use crate::vapid::signer::Claims;
-use crate::vapid::{VapidKey, VapidSignature, VapidSigner};
+use std::collections::BTreeMap;
+use std::io::Read;
+
 use http::uri::Uri;
 use jwt_simple::prelude::*;
 use serde_json::Value;
-use std::collections::BTreeMap;
-use std::io::Read;
+
+use crate::error::WebPushError;
+use crate::message::SubscriptionInfo;
+use crate::vapid::{VapidKey, VapidSignature, VapidSigner};
+use crate::vapid::signer::Claims;
 
 /// A VAPID signature builder for generating an optional signature to the
 /// request. This encryption is required for payloads in all current and future browsers.
@@ -241,10 +243,12 @@ impl<'a> PartialVapidSignatureBuilder {
 
 #[cfg(test)]
 mod tests {
+    use std::fs::File;
+
+    use ::lazy_static::lazy_static;
+
     use crate::message::SubscriptionInfo;
     use crate::vapid::VapidSignatureBuilder;
-    use ::lazy_static::lazy_static;
-    use std::fs::File;
 
     lazy_static! {
         static ref PRIVATE_PEM: File = File::open("resources/vapid_test_key.pem").unwrap();

--- a/src/vapid/key.rs
+++ b/src/vapid/key.rs
@@ -22,8 +22,9 @@ impl VapidKey {
 
 #[cfg(test)]
 mod tests {
-    use crate::vapid::key::VapidKey;
     use std::fs::File;
+
+    use crate::vapid::key::VapidKey;
 
     #[test]
     /// Tests that VapidKey derives the correct public key.

--- a/src/vapid/mod.rs
+++ b/src/vapid/mod.rs
@@ -9,4 +9,3 @@ use self::signer::VapidSigner;
 pub mod builder;
 mod key;
 mod signer;
-

--- a/src/vapid/mod.rs
+++ b/src/vapid/mod.rs
@@ -1,11 +1,12 @@
 //! Contains tooling for signing with VAPID.
 
-pub mod builder;
-mod key;
-mod signer;
-
 pub use self::builder::VapidSignatureBuilder;
 use self::key::VapidKey;
 pub use self::signer::Claims;
 pub use self::signer::VapidSignature;
 use self::signer::VapidSigner;
+
+pub mod builder;
+mod key;
+mod signer;
+

--- a/src/vapid/signer.rs
+++ b/src/vapid/signer.rs
@@ -1,12 +1,14 @@
-use crate::{error::WebPushError, vapid::VapidKey};
+use std::collections::BTreeMap;
+
 use http::uri::Uri;
 use jwt_simple::prelude::*;
 use serde_json::Value;
-use std::collections::BTreeMap;
+
+use crate::{error::WebPushError, vapid::VapidKey};
 
 /// A struct representing a VAPID signature. Should be generated using the
 /// [VapidSignatureBuilder](struct.VapidSignatureBuilder.html).
-#[derive(Debug)]
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct VapidSignature {
     /// The signed JWT, base64 encoded
     pub auth_t: String,


### PR DESCRIPTION
This PR adds commons traits such as Clone, Debug, Ord, Hash, ect. to public facing structs where logical.

Changelog
------------
[+] - Add `Clone, Ord, PartialOrd, Eq, Deserialize, Serialize, Hash` traits to public facing structs.
[+] - Bump to 0.9.1