### PR TITLE
Allow specifying the `Urgency` of each push message

### DIFF
--- a/src/clients/request_builder.rs
+++ b/src/clients/request_builder.rs
@@ -45,6 +45,10 @@ where
         .uri(message.endpoint)
         .header("TTL", format!("{}", message.ttl).as_bytes());
 
+    if let Some(urgency) = message.urgency {
+        builder = builder.header("Urgency", urgency.to_string());
+    }
+
     if let Some(payload) = message.payload {
         builder = builder
             .header(CONTENT_ENCODING, payload.content_encoding)

--- a/src/clients/request_builder.rs
+++ b/src/clients/request_builder.rs
@@ -98,6 +98,7 @@ mod tests {
     use crate::error::WebPushError;
     use crate::http_ece::ContentEncoding;
     use crate::message::WebPushMessageBuilder;
+    use crate::Urgency;
 
     #[test]
     fn builds_a_correct_request_with_empty_payload() {
@@ -114,12 +115,15 @@ mod tests {
         let mut builder = WebPushMessageBuilder::new(&info).unwrap();
 
         builder.set_ttl(420);
+        builder.set_urgency(Urgency::VeryLow);
 
         let request = build_request::<isahc::Body>(builder.build().unwrap());
         let ttl = request.headers().get("TTL").unwrap().to_str().unwrap();
+        let urgency = request.headers().get("Urgency").unwrap().to_str().unwrap();
         let expected_uri: Uri = "fcm.googleapis.com".parse().unwrap();
 
         assert_eq!("420", ttl);
+        assert_eq!("very-low", urgency);
         assert_eq!(expected_uri.host(), request.uri().host());
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,9 @@ pub use crate::clients::isahc_client::WebPushClient;
 pub use crate::clients::request_builder;
 pub use crate::error::WebPushError;
 pub use crate::http_ece::ContentEncoding;
-pub use crate::message::{SubscriptionInfo, SubscriptionKeys, WebPushMessage, WebPushMessageBuilder, WebPushPayload};
+pub use crate::message::{
+    SubscriptionInfo, SubscriptionKeys, Urgency, WebPushMessage, WebPushMessageBuilder, WebPushPayload,
+};
 pub use crate::vapid::builder::PartialVapidSignatureBuilder;
 pub use crate::vapid::{VapidSignature, VapidSignatureBuilder};
 pub use base64::{Config, BCRYPT, BINHEX, CRYPT, IMAP_MUTF7, STANDARD, STANDARD_NO_PAD, URL_SAFE, URL_SAFE_NO_PAD};

--- a/src/message.rs
+++ b/src/message.rs
@@ -54,7 +54,8 @@ pub struct WebPushPayload {
     pub content_encoding: &'static str,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
 pub enum Urgency {
     VeryLow,
     Low,

--- a/src/message.rs
+++ b/src/message.rs
@@ -54,11 +54,12 @@ pub struct WebPushPayload {
     pub content_encoding: &'static str,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone, Eq, PartialEq, Ord, PartialOrd, Default, Hash)]
 #[serde(rename_all = "kebab-case")]
 pub enum Urgency {
     VeryLow,
     Low,
+    #[default]
     Normal,
     High,
 }


### PR DESCRIPTION
This PR makes it easy to specify the message urgency as defined here - https://web.dev/push-notifications-web-push-protocol/#urgency