### PR TITLE
fix: check the server response size, should not be over 512kB

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,10 +1,9 @@
-{ pkgs ? import <nixpkgs> {} }:
-
+{pkgs ? import <nixpkgs> {}}:
 with pkgs;
-
-mkShell {
-  buildInputs = with pkgs; [
-    openssl
-    pkg-config
-  ];
-}
+  mkShell {
+    buildInputs = with pkgs; [
+      rustup
+      openssl
+      pkg-config
+    ];
+  }

--- a/src/clients/hyper_client.rs
+++ b/src/clients/hyper_client.rs
@@ -73,6 +73,10 @@ impl WebPushClient for HyperWebPushClient {
             .and_then(|s| s.parse().ok())
             .unwrap_or(0);
 
+        if content_length > super::MAX_CONTENT_LENGTH {
+            return Err(WebPushError::ResponseTooLarge(content_length));
+        }
+
         let mut body: Vec<u8> = Vec::with_capacity(content_length);
         let mut chunks = response.into_body();
 

--- a/src/clients/isahc_client.rs
+++ b/src/clients/isahc_client.rs
@@ -74,6 +74,10 @@ impl WebPushClient for IsahcWebPushClient {
             .and_then(|s| s.parse().ok())
             .unwrap_or(0);
 
+        if content_length > super::MAX_CONTENT_LENGTH {
+            return Err(WebPushError::ResponseTooLarge(content_length));
+        }
+
         let mut body: Vec<u8> = Vec::with_capacity(content_length);
         let mut chunks = response.into_body();
 

--- a/src/clients/mod.rs
+++ b/src/clients/mod.rs
@@ -14,6 +14,9 @@ pub mod hyper_client;
 #[cfg(feature = "isahc-client")]
 pub mod isahc_client;
 
+/// We should not handle larger bodies than 512kB.
+const MAX_CONTENT_LENGTH: usize = 512_000;
+
 /// An async client for sending the notification payload.
 /// Other features, such as thread safety, may vary by implementation.
 #[async_trait]

--- a/src/error.rs
+++ b/src/error.rs
@@ -64,6 +64,8 @@ pub enum WebPushError {
     InvalidResponse,
     /// A claim had invalid data
     InvalidClaims,
+    /// The response was too large
+    ResponseTooLarge(usize),
     Other(ErrorInfo),
 }
 
@@ -133,6 +135,7 @@ impl WebPushError {
             WebPushError::InvalidCryptoKeys => "invalid_crypto_keys",
             WebPushError::Io(_) => "io_error",
             WebPushError::Other(_) => "other",
+            WebPushError::ResponseTooLarge(_) => "response_too_large",
             WebPushError::InvalidClaims => "invalidClaims",
         }
     }
@@ -160,6 +163,7 @@ impl fmt::Display for WebPushError {
             WebPushError::InvalidResponse => write!(f, "could not parse response data"),
             WebPushError::MissingCryptoKeys => write!(f, "request is missing cryptographic keys"),
             WebPushError::InvalidCryptoKeys => write!(f, "request has invalid cryptographic keys"),
+            WebPushError::ResponseTooLarge(size) => write!(f, "response too large: {} bytes", size),
             WebPushError::Other(info) => write!(f, "other: {}", info),
             WebPushError::InvalidClaims => write!(f, "at least one jwt claim was invalid"),
         }


### PR DESCRIPTION
The server can be any arbitrary web push server. We should have control what is the response size due to allocating a vector based on this value. 