### PR TITLE
Work around symbol conflict between BoringSSL and OpenSSL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ http = "^0.2"
 serde = "^1.0"
 serde_json = "^1.0"
 serde_derive = "^1.0"
-jwt-simple = "0.12"
+jwt-simple = { version = "0.12", default-features = false, features = ["pure-rust"] }
 ece = "^2.2"
 pem = "3"
 sec1_decode = "^0.1.0"


### PR DESCRIPTION
Currently linking the crate may fail with many "undefined reference" errors due to conflicting symbols.

We depend on openssl-sys via ece and isahc.

We depend on boring-sys via jwt-simple, but only for its RSA implementation.

As a workaround, enable jwt-simple's pure Rust feature. This affects only the RSA implementation in jwt-simple, which we do not even use. Hopefully, a future jwt-simple version makes RSA entirely optional or supports selecting OpenSSL as a crypto backend.