### PR TITLE
Limit push endpoint response size

### DIFF
--- a/src/clients/mod.rs
+++ b/src/clients/mod.rs
@@ -14,6 +14,8 @@ pub mod hyper_client;
 #[cfg(feature = "isahc-client")]
 pub mod isahc_client;
 
+const MAX_RESPONSE_SIZE: usize = 64 * 1024;
+
 /// An async client for sending the notification payload.
 /// Other features, such as thread safety, may vary by implementation.
 #[async_trait]

--- a/src/error.rs
+++ b/src/error.rs
@@ -64,6 +64,8 @@ pub enum WebPushError {
     InvalidResponse,
     /// A claim had invalid data
     InvalidClaims,
+    /// Response from push endpoint was too large
+    ResponseTooLarge,
     Other(ErrorInfo),
 }
 
@@ -134,6 +136,7 @@ impl WebPushError {
             WebPushError::Io(_) => "io_error",
             WebPushError::Other(_) => "other",
             WebPushError::InvalidClaims => "invalidClaims",
+            WebPushError::ResponseTooLarge => "response_too_large",
         }
     }
 }
@@ -162,6 +165,7 @@ impl fmt::Display for WebPushError {
             WebPushError::InvalidCryptoKeys => write!(f, "request has invalid cryptographic keys"),
             WebPushError::Other(info) => write!(f, "other: {}", info),
             WebPushError::InvalidClaims => write!(f, "at least one jwt claim was invalid"),
+            WebPushError::ResponseTooLarge => write!(f, "response from push endpoint was too large"),
         }
     }
 }


### PR DESCRIPTION
Another attempt at #64.

* Does not trust `Content-Length` at all.
* Will not allocate more than 64 KiB plus one frame, even on chunked responses.