### PR TITLE
Remove padding = from openssl base64 public key

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ openssl ecparam -genkey -name prime256v1 -out private_key.pem
 To derive a public key from the just-generated private key, to be used in the JavaScript client:
 
 ```
-openssl ec -in private_key.pem -pubout -outform DER|tail -c 65|base64|tr '/+' '_-'|tr -d '\n'
+openssl ec -in private_key.pem -pubout -outform DER|tail -c 65|base64|tr '/+' '_-'|tr -d '\n='
 ```
 
 The signature is created with `VapidSignatureBuilder`. It automatically adds the required claims `aud` and `exp`. Adding


### PR DESCRIPTION
When I attempt to register/subscribe to web push notifications, and the base64 public key contains padding (one or two `=` terminal characters) browsers yield these errors:

- Chrome 132: "_InvalidCharacterError: Failed to execute 'subscribe' on 'PushManager': The provided applicationServerKey is not encoded as base64url without padding._"
- Firefox 134: "_DOMException: String contains an invalid character_"

Simply deleting these seems to work for me, so this change adds `=` to the `tr` deleted character set in the public key `openssl` command.

For folks curious why this padding exists: https://en.wikipedia.org/wiki/Base64#Output_padding